### PR TITLE
Fix typos in docs

### DIFF
--- a/src/interp/mod.rs
+++ b/src/interp/mod.rs
@@ -13,7 +13,7 @@ pub use spline::*;
 
 /// Create a Lagrange interpolating polynomial.
 ///
-/// Create an nth degree polynomial matching the n points (xs[i], ys[i])
+/// Create an nth degree polynomial matching the n points (xs\[i\], ys\[i\])
 /// using Neville's iterated method for Lagrange polynomials. The result will
 /// match no derivatives.
 ///

--- a/src/interp/spline.rs
+++ b/src/interp/spline.rs
@@ -61,7 +61,7 @@ where
 /// `xs` x points. Must be real because cubic splines keep track of ranges within
 /// which it interpolates. Must be sorted.
 ///
-/// `ys` y points. Can be complex. ys[i] must match with xs[i].
+/// `ys` y points. Can be complex. ys\[i\] must match with xs\[i\].
 ///
 /// `tol` the tolerance of the polynomials
 ///
@@ -178,7 +178,7 @@ where
 /// `xs` x points. Must be real because cubic splines keep track of ranges within
 /// which it interpolates. Must be sorted.
 ///
-/// `ys` y points. Can be complex. ys[i] must match with xs[i].
+/// `ys` y points. Can be complex. ys\[i\] must match with xs\[i\].
 ///
 /// `(f_0, f_n)` The derivative values at the end points.
 ///

--- a/src/ivp.rs
+++ b/src/ivp.rs
@@ -14,8 +14,8 @@ pub mod adams;
 pub mod bdf;
 pub mod rk;
 
-/// Status returned from the IVPStepper
-/// Used by the IVPIterator struct to correctly step through
+/// Status returned from the [`IVPStepper`]
+/// Used by the [`IVPIterator`] struct to correctly step through
 /// the IVP solution.
 #[derive(Error, Clone, Debug)]
 pub enum IVPStatus<T: Error> {
@@ -90,14 +90,14 @@ impl From<DimensionError> for IVPError {
     }
 }
 
-/// A type alias for a Result of a IVPStepper step
+/// A type alias for a Result of a [`IVPStepper`] step
 /// Ok is a tuple of the time and solution at that time
 /// Err is an IVPError
 pub type Step<R, C, D, E> = Result<(R, BVector<C, D>), IVPStatus<E>>;
 
 /// Implementing this trait is providing the main functionality of
 /// an initial value problem solver. This should be used only when
-/// implementing an IVPSolver, users should use the solver via the IVPSolver
+/// implementing an [`IVPSolver`], users should use the solver via the [`IVPSolver`]
 /// trait's interface.
 pub trait IVPStepper<D: Dimension>: Sized
 where
@@ -128,7 +128,7 @@ where
 /// Build up the solver using the parameter builder functions and then use solve.
 ///
 /// This is used as a builder pattern, setting parameters of the solver.
-/// IVPSolver implementations should implement a step function that
+/// [`IVPSolver`] implementations should implement a step function that
 /// returns an IVPStatus, then a blanket impl will allow it to be used as an
 /// IntoIterator for the user to iterate over the results.
 pub trait IVPSolver<'a, D: Dimension>: Sized
@@ -284,7 +284,7 @@ where
 }
 
 /// The struct that actually solves an IVP with Euler's method
-/// Is the associated IVPStepper for Euler (the IVPSolver)
+/// Is the associated [`IVPStepper`] for Euler (the IVPSolver)
 /// You should use Euler and not this type directly
 pub struct EulerSolver<'a, N, D, T, F>
 where

--- a/src/ivp/adams.rs
+++ b/src/ivp/adams.rs
@@ -14,7 +14,7 @@ use std::collections::VecDeque;
 use std::marker::PhantomData;
 
 /// This trait defines an Adams predictor-corrector solver
-/// The Adams struct takes an implemetation of this trait
+/// The [`Adams`] struct takes an implemetation of this trait
 /// as a type argument since the algorithm is the same for
 /// all the predictor correctors, just the order and these functions
 /// need to be different.
@@ -602,7 +602,7 @@ impl<N: ComplexField> AdamsCoefficients<5> for AdamsCoefficients5<N> {
 /// 5th order Adams predictor-corrector method for solving an IVP.
 ///
 /// Defines the predictor and corrector coefficients, as well as
-/// the error coefficient. Uses Adams for the actual solving.
+/// the error coefficient. Uses [`Adams`] for the actual solving.
 ///
 /// # Examples
 /// ```
@@ -661,7 +661,7 @@ impl<N: ComplexField + Copy> AdamsCoefficients<3> for AdamsCoefficients3<N> {
 /// 3rd order Adams predictor-corrector method for solving an IVP.
 ///
 /// Defines the predictor and corrector coefficients, as well as
-/// the error coefficient. Uses Adams for the actual solving.
+/// the error coefficient. Uses [`Adams`] for the actual solving.
 ///
 /// # Examples
 /// ```

--- a/src/ivp/bdf.rs
+++ b/src/ivp/bdf.rs
@@ -14,7 +14,7 @@ use std::collections::VecDeque;
 use std::marker::PhantomData;
 
 /// This trait defines an BDF solver
-/// The BDF struct takes an implemetation of this trait
+/// The [`BDF`] struct takes an implemetation of this trait
 /// as a type argument since the algorithm is the same for
 /// all the orders, just the constants are different.
 pub trait BDFCoefficients<const O: usize> {
@@ -68,7 +68,7 @@ where
 /// The solver for any BDF predictor-corrector
 /// Users should not use this type directly, and should
 /// instead get it from a specific BDF method struct
-/// (wrapped in an IVPIterator)
+/// (wrapped in an [`IVPIterator`])
 pub struct BDFSolver<'a, N, D, const O: usize, T, F>
 where
     D: Dimension,
@@ -676,7 +676,7 @@ impl<N: ComplexField> BDFCoefficients<7> for BDF6Coefficients<N> {
 /// solving an initial value problem.
 ///
 /// Defines the higher and lower order coefficients. Uses
-/// BDFInfo for the actual solving.
+/// [`BDFInfo`] for the actual solving.
 ///
 /// # Examples
 /// ```
@@ -733,7 +733,7 @@ impl<N: ComplexField> BDFCoefficients<3> for BDF2Coefficients<N> {
 /// solving an initial value problem.
 ///
 /// Defines the higher and lower order coefficients. Uses
-/// BDFInfo for the actual solving.
+/// [`BDFInfo`] for the actual solving.
 ///
 /// # Examples
 /// ```

--- a/src/ivp/rk.rs
+++ b/src/ivp/rk.rs
@@ -13,7 +13,7 @@ use num_traits::{FromPrimitive, One, Zero};
 use std::marker::PhantomData;
 
 /// This trait defines a Runge-Kutta solver
-/// The RungeKutta struct takes an implemetation of this trait
+/// The [`RungeKutta`] struct takes an implementation of this trait
 /// as a type argument since the algorithm is the same for
 /// all the methods, just the order and these functions
 /// need to be different.
@@ -21,25 +21,25 @@ pub trait RungeKuttaCoefficients<const O: usize> {
     /// The real field associated with the solver's Field.
     type RealField: RealField;
 
-    /// Returns a vec of coeffecients to multiply the time step by when getting
-    /// intermediate results. Upper-left portion of Butch Tableaux
+    /// Returns a vec of coefficients to multiply the time step by when getting
+    /// intermediate results. Upper-left portion of Butcher Tableaux
     fn t_coefficients() -> Option<BSVector<Self::RealField, O>>;
 
     /// Returns the coefficients to use on the k_i's when finding another
-    /// k_i. Upper-right portion of the Butch Tableax. Should be
+    /// k_i. Upper-right portion of the Butcher Tableaux. Should be
     /// an NxN-1 matrix, where N is the order of the Runge-Kutta Method (Or order+1 for
     /// adaptive methods)
     fn k_coefficients() -> Option<BSMatrix<Self::RealField, O, O>>;
 
     /// Coefficients to use when calculating the final step to take.
     /// These are the weights of the weighted average of k_i's. Bottom
-    /// portion of the Butch Tableaux. For adaptive methods, this is the first
+    /// portion of the Butcher Tableaux. For adaptive methods, this is the first
     /// row of the bottom portion.
     fn avg_coefficients() -> Option<BSVector<Self::RealField, O>>;
 
     /// Coefficients to use on
     /// the k_i's to find the error between the two orders
-    /// of Runge-Kutta methods. In the Butch Tableaux, this is
+    /// of Runge-Kutta methods. In the Butcher Tableaux, this is
     /// the first row of the bottom portion minus the second row.
     fn error_coefficients() -> Option<BSVector<Self::RealField, O>>;
 }
@@ -192,7 +192,7 @@ where
     }
 
     /// Will overwrite any previously set value
-    /// If the provided minimum is greatear than a previously set maximum, then the maximum
+    /// If the provided minimum is greater than a previously set maximum, then the maximum
     /// is set to this value as well.
     fn with_minimum_dt(mut self, min: Self::RealField) -> Result<Self, Self::Error> {
         if min <= <Self::RealField as Zero>::zero() {
@@ -527,9 +527,9 @@ impl<N: ComplexField> RungeKuttaCoefficients<6> for RKCoefficients45<N> {
 
 /// Runge-Kutta-Fehlberg method for solving an IVP.
 ///
-/// Defines the Butch Tableaux for a 5(4) order adaptive
-/// runge-kutta method. Uses RungeKutta to do the actual solving.
-/// Provides an implementation of the IVPSolver trait.
+/// Defines the Butcher Tableaux for a 5(4) order adaptive
+/// runge-kutta method. Uses [`RungeKutta`] to do the actual solving.
+/// Provides an implementation of the [`IVPSolver`] trait.
 ///
 /// # Examples
 /// ```
@@ -622,9 +622,9 @@ impl<N: ComplexField> RungeKuttaCoefficients<4> for RK23Coefficients<N> {
 
 /// Bogacki-Shampine method for solving an IVP.
 ///
-/// Defines the Butch Tableaux for a 5(4) order adaptive
-/// runge-kutta method. Uses RungeKutta to do the actual solving.
-/// Provides an implementation of the IVPSolver trait.
+/// Defines the Butcher Tableaux for a 5(4) order adaptive
+/// Runge-Kutta method. Uses [`RungeKutta`] to do the actual solving.
+/// Provides an implementation of the [`IVPSolver`] trait.
 ///
 /// # Examples
 /// ```

--- a/src/ivp/rk.rs
+++ b/src/ivp/rk.rs
@@ -70,8 +70,8 @@ where
 
 /// The solver for any Runge-Kutta method
 /// Users should not use this type directly, and should
-/// instead get it from a specific RungeKutta struct
-/// (wrapped in an IVPIterator)
+/// instead get it from a specific [`RungeKutta`] struct
+/// (wrapped in an [`IVPIterator`])
 pub struct RungeKuttaSolver<'a, N, D, const O: usize, T, F>
 where
     D: Dimension,
@@ -95,7 +95,7 @@ where
     dt: N,
     state: BVector<N, D>,
 
-    // Per-order constants set by RungeKuttaCoefficients
+    // Per-order constants set by [`RungeKuttaCoefficients`]
     t_coefficients: BSVector<N, O>,
     k_coefficients: BSMatrix<N, O, O>,
     avg_coefficients: BSVector<N, O>,
@@ -528,7 +528,7 @@ impl<N: ComplexField> RungeKuttaCoefficients<6> for RKCoefficients45<N> {
 /// Runge-Kutta-Fehlberg method for solving an IVP.
 ///
 /// Defines the Butcher Tableaux for a 5(4) order adaptive
-/// runge-kutta method. Uses [`RungeKutta`] to do the actual solving.
+/// Runge-Kutta method. Uses [`RungeKutta`] to do the actual solving.
 /// Provides an implementation of the [`IVPSolver`] trait.
 ///
 /// # Examples

--- a/src/optimize/mod.rs
+++ b/src/optimize/mod.rs
@@ -384,7 +384,7 @@ where
 /// Uses an analytic jacobian.Keeps iterating until
 /// the differences between the sum of the square residuals of two iterations
 /// is under tol. Jacobian should be a function that returns a column vector
-/// where jacobian[i] is the partial derivative of f with respect to param[i].
+/// where jacobian\[i\] is the partial derivative of f with respect to param\[i\].
 ///
 /// # Errors
 /// Returns an error if curve fit fails.

--- a/src/optimize/mod.rs
+++ b/src/optimize/mod.rs
@@ -8,7 +8,7 @@ use num_traits::{FromPrimitive, One, Zero};
 /// Returns an error if the linear fit fails. (`xs.len() != ys.len()`)
 ///
 /// # Panics
-/// Panics if a `usize` can not be transformed into the generic type.
+/// Panics if a [`usize`] cannot be transformed into the generic type.
 pub fn linear_fit<N>(xs: &[N], ys: &[N]) -> Result<Polynomial<N>, String>
 where
     N: ComplexField + FromPrimitive + Copy,
@@ -244,7 +244,7 @@ where
 /// Fit a curve using the Levenberg-Marquardt algorithm.
 ///
 /// Uses finite differences of h to calculate the jacobian. If jacobian
-/// can be found analytically, then use `curve_fit_jac`. Keeps iterating until
+/// can be found analytically, then use [`curve_fit_jac`]. Keeps iterating until
 /// the differences between the sum of the square residuals of two iterations
 /// is under tol.
 ///
@@ -390,7 +390,7 @@ where
 /// Returns an error if curve fit fails.
 ///
 /// # Panics
-/// Panics if a u8 can not be converted to the generic type.
+/// Panics if a [`u8`] can not be converted to the generic type.
 pub fn curve_fit_jac<N, F, G, const V: usize>(
     mut f: F,
     xs: &[N],

--- a/src/polynomial/mod.rs
+++ b/src/polynomial/mod.rs
@@ -5,7 +5,7 @@ use num_traits::{FromPrimitive, One, Zero};
 use std::collections::VecDeque;
 use std::{any::TypeId, f64, iter::FromIterator, ops};
 
-/// Polynomial on a ComplexField.
+/// Polynomial on a [`ComplexField`].
 #[derive(Debug, Clone)]
 pub struct Polynomial<N: ComplexField + FromPrimitive + Copy>
 where

--- a/src/polynomial/mod.rs
+++ b/src/polynomial/mod.rs
@@ -87,7 +87,7 @@ where
         self.coefficients.len() - 1
     }
 
-    /// Returns the coefficients in the correct order to recreate the polynomial with Polynomial::from_slice(data: &[N]);
+    /// Returns the coefficients in the correct order to recreate the polynomial with [`Polynomial::from_slice`]
     pub fn get_coefficients(&self) -> Vec<N> {
         let mut cln = self.coefficients.clone();
         cln.reverse();


### PR DESCRIPTION
I noticed a few typos while going through the docs, so I thought I would send a PR to fix them!

I also took that opportunity to fix some unescaped square brackets and add some links in the docs for convenience. Most of the links were added in the last commit, so it can easily be reverted in case that's not actually desirable.