### PR TITLE
fix: rk23 coefficient

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,6 @@ readme = "README.md"
 keywords =["numeric", "science", "integration", "quadrature"]
 categories =["science"]
 
-[dev-dependencies]
-float-cmp = "0.9"
-rand = "0.8"
-rstest = "0.26.1"
-
 [dependencies]
 nalgebra = "0.32"
 num-complex = "0.4"
@@ -26,3 +21,8 @@ typenum = "1.17"
 
 [build-dependencies]
 phf_codegen = "0.11"
+
+[dev-dependencies]
+float-cmp = "0.9"
+rand = "0.8"
+rstest = "0.26.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories =["science"]
 [dev-dependencies]
 float-cmp = "0.9"
 rand = "0.8"
+rstest = "0.26.1"
 
 [dependencies]
 nalgebra = "0.32"

--- a/src/ivp/rk.rs
+++ b/src/ivp/rk.rs
@@ -622,7 +622,7 @@ impl<N: ComplexField> RungeKuttaCoefficients<4> for RK23Coefficients<N> {
 
 /// Bogacki-Shampine method for solving an IVP.
 ///
-/// Defines the Butcher Tableaux for a 5(4) order adaptive
+/// Defines the Butcher Tableaux for a 3(2) order adaptive
 /// Runge-Kutta method. Uses [`RungeKutta`] to do the actual solving.
 /// Provides an implementation of the [`IVPSolver`] trait.
 ///

--- a/src/ivp/rk.rs
+++ b/src/ivp/rk.rs
@@ -615,7 +615,7 @@ impl<N: ComplexField> RungeKuttaCoefficients<4> for RK23Coefficients<N> {
             -Self::RealField::from_u8(5)? / Self::RealField::from_u8(72)?,
             Self::RealField::from_u8(12)?.recip(),
             Self::RealField::from_u8(9)?.recip(),
-            Self::RealField::from_u8(8)?.recip(),
+            -Self::RealField::from_u8(8)?.recip(),
         ]))
     }
 }
@@ -709,6 +709,76 @@ mod test {
         let t_final = 10.0;
 
         let solver = RungeKutta45::new()
+            .unwrap()
+            .with_minimum_dt(0.001)
+            .unwrap()
+            .with_maximum_dt(0.01)
+            .unwrap()
+            .with_tolerance(0.0001)
+            .unwrap()
+            .with_initial_time(t_initial)
+            .unwrap()
+            .with_ending_time(t_final)
+            .unwrap()
+            .with_initial_conditions_slice(&[0.0])
+            .unwrap()
+            .with_derivative(sine_deriv)
+            .solve(())
+            .unwrap();
+
+        let path = solver.collect_vec().unwrap();
+
+        for step in &path {
+            assert!(approx_eq!(
+                f64,
+                step.1.column(0)[0],
+                step.0.sin(),
+                epsilon = 0.01
+            ));
+        }
+    }
+
+    #[test]
+    fn rungekutta23_quadratic() {
+        let t_initial = 0.0;
+        let t_final = 10.0;
+
+        let solver = RungeKutta23::new()
+            .unwrap()
+            .with_minimum_dt(0.0001)
+            .unwrap()
+            .with_maximum_dt(0.1)
+            .unwrap()
+            .with_initial_time(t_initial)
+            .unwrap()
+            .with_ending_time(t_final)
+            .unwrap()
+            .with_tolerance(1e-5)
+            .unwrap()
+            .with_initial_conditions_slice(&[1.0])
+            .unwrap()
+            .with_derivative(quadratic_deriv)
+            .solve(())
+            .unwrap();
+
+        let path = solver.collect_vec().unwrap();
+
+        for step in &path {
+            assert!(approx_eq!(
+                f64,
+                step.1.column(0)[0],
+                1.0 - step.0.powi(2),
+                epsilon = 0.0001
+            ));
+        }
+    }
+
+    #[test]
+    fn rungekutta23_sine() {
+        let t_initial = 0.0;
+        let t_final = 10.0;
+
+        let solver = RungeKutta23::new()
             .unwrap()
             .with_minimum_dt(0.001)
             .unwrap()


### PR DESCRIPTION
While looking at the code I noticed that the last error coefficient for the RK3(2) scheme was missing a minus sign.

This wasn't noticed because there was no unit test for this solver and because the doc tests do not actually run since the function that's supposed to execute code is called `example` instead of `main`. Without the minus sign, the RK5(4) tests fail for RK3(2). BTW, neither the RK5(4) example nor the RK3(2) example (even after fixing the sign) runs successfully (I'm not sure why, the tests in the test module do run successfully).

I took that opportunity to fix the doc comment for the RK3(2) scheme which had 5(4) in it.

Note that after a bit of tinkering I was able to leverage [rstest](https://github.com/la10736/rstest) to make the RK tests parametrized over the solver so as to avoid code duplication (finding the right type with the right generics wasn't easy...).